### PR TITLE
Add link() in build.zig for being used as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Zelda uses [hzzp](https://github.com/truemedian/hzzp) and [zig-libressl](https:/
 - [x] TLS 1.1, TLS 1.2, TLS 1.3
 - [x] Simple One-Shot interface for raw bytes & JSON encoded data
 
+### Linking
+
+```zig
+const zelda = @import("path/to/zelda/build.zig");
+
+pub fn build(b: *std.build.Builder) !void {
+    const exe = ...
+    try zelda.link(b, exe, target, mode, use_system_libressl);
+}
+```
+
 ### Example
 ```zig
 /// Extracted from `examples/whats_my_ip/src/main.zig`

--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
-const zig_libressl = @import("zig-libressl/build.zig");
+pub const zig_libressl = @import("zig-libressl/build.zig");
 const Pkg = std.build.Pkg;
 
 fn relativeToThis(comptime path: []const u8) []const u8 {
     comptime {
-        return std.fs.path.dirname(@src().file).? ++ "/" ++ path;
+        const fspath = std.fs.path;
+        return fspath.dirname(@src().file).? ++ fspath.sep_str ++ path;
     }
 }
 
@@ -26,12 +27,23 @@ pub const pkgs = struct {
 
     pub const zelda = Pkg{
         .name = "zelda",
-        .source = .{ .path = "src/main.zig" },
+        .source = .{ .path = relativeToThis("src/main.zig") },
         .dependencies = &[_]Pkg{
             hzzp, zuri, libressl,
         },
     };
 };
+
+pub fn link(
+    b: *std.build.Builder,
+    exe: *std.build.LibExeObjStep,
+    target: std.zig.CrossTarget,
+    mode: std.builtin.Mode,
+    use_system_libressl: bool,
+) !void {
+    exe.addPackage(pkgs.zelda);
+    try zig_libressl.useLibreSslForStep(b, target, mode, relativeToThis("zig-libressl/libressl"), exe, use_system_libressl);
+}
 
 pub fn build(b: *std.build.Builder) !void {
     const use_system_libressl = b.option(bool, "use-system-libressl", "Link and build from the system installed copy of LibreSSL instead of building it from source") orelse false;
@@ -48,8 +60,7 @@ pub fn build(b: *std.build.Builder) !void {
     create_test_step.sanitize_thread = sanitize_thread;
     create_test_step.setTarget(target);
     create_test_step.setBuildMode(mode);
-    create_test_step.addPackage(pkgs.zelda);
-    try zig_libressl.useLibreSslForStep(b, target, mode, "zig-libressl/libressl", create_test_step, use_system_libressl);
+    try link(b, create_test_step, target, mode, use_system_libressl);
 
     if (maybe_test_filter) |test_filter| {
         create_test_step.setFilter(test_filter);


### PR DESCRIPTION
P.S. zig-libressl doesn't build on my machine (Arch Linux) unless I use the "use system library" option.

On Arch Linux it's as easy as `pacman -S libressl` to install LibreSSL.